### PR TITLE
Update ReferralGrid to make sure the markup is still accepted in 1.0

### DIFF
--- a/core/components/commerce_referrals/src/Admin/Referral/ReferralGrid.php
+++ b/core/components/commerce_referrals/src/Admin/Referral/ReferralGrid.php
@@ -72,6 +72,7 @@ class ReferralGrid extends GridWidget {
                 'name' => 'order',
                 'title' => $this->adapter->lexicon('commerce_referrals.referral.order'),
                 'sortable' => true,
+                'raw' => true,
             ],
         ];
     }


### PR DESCRIPTION
As of v1.0, all grid values are automatically escaped unless the `raw` column property is provided. As the `order` contains a link, this needs to be added. 